### PR TITLE
fix: remove hardcoded product IDs from Tremendous reward orders

### DIFF
--- a/controllers/campaignController.js
+++ b/controllers/campaignController.js
@@ -362,14 +362,7 @@ const sendReward = async (rewardData) => {
           },
           delivery: {
             method: "EMAIL"
-          },
-          products: [
-            "Q24BD9EZ332JT",
-            "TKIHHHAJU20C",
-            "KV934TZ93NQM",
-            "ET0ZVETV5ILN",
-            "OKMHM2X2OHYV"
-          ]
+          }
         }
       ],
       campaign_id: process.env.TREMENDOUS_CAMPAIGN_ID


### PR DESCRIPTION
## Summary

- Remove hardcoded `products[]` array from Tremendous order payload in `sendReward()`
- When both `products` and `campaign_id` are sent, Tremendous treats the order as product-based and ignores the campaign's fee pass-through setting — causing the 4% monetary option fee to be charged to the account instead of the recipient
- With `products[]` removed, `campaign_id` alone drives product selection and all campaign settings (including fee pass-through) apply automatically

## Root Cause

Tremendous support confirmed (Apr 23, 2026) that orders submitted with explicit product IDs bypass campaign-level configuration. The campaign `1OO1Y5FO4NZ7` is correctly configured to pass fees to recipients, but the hardcoded `products[]` in the payload overrode that setting.

## Changes

- `controllers/campaignController.js`: Removed `products` field from the reward object in `sendReward()`

## Test Plan
- [ ] Send a test reward and verify the order is associated with campaign `1OO1Y5FO4NZ7` in Tremendous dashboard
- [ ] Confirm the 4% fee is passed to recipient, not charged to account
- [ ] Verify recipient still receives the reward email with product selection options defined by the campaign

🤖 Generated with [Claude Code](https://claude.com/claude-code)