### PR TITLE
fix: move campaign_id inside rewards array for Tremendous API

### DIFF
--- a/controllers/campaignController.js
+++ b/controllers/campaignController.js
@@ -352,6 +352,7 @@ const sendReward = async (rewardData) => {
       },
       rewards: [
         {
+          campaign_id: process.env.TREMENDOUS_CAMPAIGN_ID,
           value: {
             denomination: parseFloat(rewardData.amount),
             currency_code: "USD"
@@ -364,8 +365,7 @@ const sendReward = async (rewardData) => {
             method: "EMAIL"
           }
         }
-      ],
-      campaign_id: process.env.TREMENDOUS_CAMPAIGN_ID
+      ]
     };
     const response = await fetch('https://api.tremendous.com/api/v2/orders', {
       method: 'POST',

--- a/controllers/campaignController.js
+++ b/controllers/campaignController.js
@@ -367,7 +367,10 @@ const sendReward = async (rewardData) => {
         }
       ]
     };
-    const response = await fetch('https://api.tremendous.com/api/v2/orders', {
+    const tremendousUrl = process.env.TREMENDOUS_SANDBOX === 'true'
+      ? 'https://testflight.tremendous.com/api/v2/orders'
+      : 'https://api.tremendous.com/api/v2/orders';
+    const response = await fetch(tremendousUrl, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${process.env.TREMENDOUS_API_KEY}`,
@@ -406,8 +409,10 @@ export const updateRewardStatus = asyncHandler(async (req, res) => {
       return res.status(404).json({ success: false, message: "Submission not found" });
     }
 
-    // Only the campaign owner can send rewards
-    if (submission.campaign_owner_id !== req.user) {
+    // Only the campaign owner or admin can send rewards
+    const requestingUser = await getUsersById(req.user);
+    const isAdmin = requestingUser?.[0]?.user_type === 0;
+    if (!isAdmin && Number(submission.campaign_owner_id) !== Number(req.user)) {
       return res.status(403).json({ success: false, message: "Not authorized to send reward for this campaign" });
     }
 


### PR DESCRIPTION
## Summary
- Moved \`campaign_id\` from the top-level payload into the \`rewards[]\` array object for Tremendous API calls
- Previously the API silently ignored \`campaign_id\` at the top level, causing an Unknown error response
- Added admin user bypass so admins can send rewards regardless of campaign ownership
- Added sandbox URL support via \`TREMENDOUS_SANDBOX\` env var for local testing

## Test plan
- [ ] Run \`git pull && pm2 restart adex-server\` on production server
- [ ] Subscribe to a campaign and confirm reward email is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)